### PR TITLE
Update ExporterButton.js

### DIFF
--- a/ExporterButton.js
+++ b/ExporterButton.js
@@ -64,9 +64,6 @@ Ext.define("Ext.ux.exporter.ExporterButton", {
             }
             me.setComponent(me.store || me.component || me.up("gridpanel") || me.up("treepanel"), config);
         });
-        this.addEvents(
-            'start',
-            'complete');
     },
     
     onClick: function(e) {


### PR DESCRIPTION
Removed:

```
    this.addEvents(
        'start',
        'complete');
```

No longer required in ExtJS 5 as Ext.util.Observable#addEvents" is deprecated.  Custom events can now be fired without prior addEvents.

Returns functionality to normal in ExtJS 5 and prevents below error for occurring:
Uncaught Error: "Ext.util.Observable # addEvents" is deprecated.
